### PR TITLE
Don't monkeypatch ActionController::TestCase

### DIFF
--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -12,7 +12,6 @@ begin
   ActiveSupport.on_load(:action_controller) do
     if ::ActionController::Serialization.enabled
       ActionController::Base.send(:include, ::ActionController::Serialization)
-      ActionController::TestCase.send(:include, ::ActionController::SerializationAssertions)
     end
   end
 rescue LoadError


### PR DESCRIPTION
#### Purpose
This gem references `ActionController::TestCase` in its standard execution path, which triggers Rails' autoload behaviour:

https://github.com/rails/rails/blob/f0148021b7e620cdf3e28aac1e0fc990aacb9d6e/actionpack/lib/action_controller.rb#L65

By referencing that object, it brings in all of the patches defined in `ActionController::TestCase` to the development and production environment, including behaviours like disabling the threading implementation of `ActionController::Live` (how I discovered this):

https://github.com/rails/rails/blob/f0148021b7e620cdf3e28aac1e0fc990aacb9d6e/actionpack/lib/action_controller/test_case.rb#L24

#### Changes
Removes automatic inclusion of `ActionController::SerializationAssertions` into `ActionController::TestCase`.

#### Caveats
Our test classes will no longer support `#assert_serializer` out of the box, but that is currently unused in our codebase, as far as I can tell. This code also no longer exists upstream.

#### Additional helpful information
The alternative approach would be to include this in `ActionController::TestCase` when the test environment is loaded, but I was unclear on the expected dependencies of this gem and if checking for the Rails environment was acceptable inside of this path. Open to alternatives!